### PR TITLE
[TASK] [AB#130750] Make the local env option use the staging env.

### DIFF
--- a/src/services/tagging_service.ts
+++ b/src/services/tagging_service.ts
@@ -15,12 +15,11 @@ export interface TagOutput extends Tag {
 export class TaggingService extends BaseService {
   discoverUrlPrefix(): string {
     switch (this.environment) {
-      case 'local':
-        return 'http://localhost:4000';
       case 'production':
         return `https://tagging.services.${this.baseDomain}`;
       case 'development':
-        return `https://${this.environment}-tagging.services.${this.baseDomain}`;
+      case 'local':
+        return `https://staging-tagging.services.${this.baseDomain}`;
       default:
         throw new Error(`Unknown environment: ${this.environment}`);
     }

--- a/src/services/user_settings.ts
+++ b/src/services/user_settings.ts
@@ -3,11 +3,10 @@ import BaseService from './base_service.js';
 export class UserSettings extends BaseService {
   discoverUrlPrefix(): string {
     switch (this.environment) {
-      case 'local':
-        return 'http://localhost:4000';
       case 'production':
         return `https://user-settings-service.services.${this.baseDomain}`;
       case 'development':
+      case 'local':
         return `https://${this.environment}-user-settings-service.services.${this.baseDomain}`;
       default:
         throw new Error(`Unknown environment: ${this.environment}`);


### PR DESCRIPTION
Using local for "local-dev" was just plain wrong. We'll need a better approach. I'll look into adding a general "override" option, that allows one to override the endpoint and credentials per endpoint, in a general manner.