### PR TITLE
Enable to view local client settings changes

### DIFF
--- a/src/services/user_settings_base.ts
+++ b/src/services/user_settings_base.ts
@@ -6,9 +6,10 @@ export class UserSettingsBase extends BaseService {
       case 'production':
         return `https://user-settings-service.services.${this.baseDomain}`;
       case 'development':
-      case 'local':
       case 'testing':
         return `https://staging-user-settings-service.services.${this.baseDomain}`;
+        case 'local':
+        return `http://localhost:4000/`;
       case 'test':
         return `https://localhost:3010/services/usersettingsservice`;
       default:


### PR DESCRIPTION
This pull request updates the `UserSettingsBase` service to correctly handle the `local` environment by specifying a unique URL for it.

* **Environment-specific URL handling:**
  * [`src/services/user_settings_base.ts`](diffhunk://#diff-fb24c109d550b992354b14c124300f842deb9f8dfd3d6e3e4745f5823f1efea1L9-R12): Adjusted the logic to assign `http://localhost:4000/` as the URL for the `local` environment, ensuring it is distinct from the `testing` environment.