### PR TITLE
Fix url for local client settings

### DIFF
--- a/src/services/user_settings_base.ts
+++ b/src/services/user_settings_base.ts
@@ -9,7 +9,7 @@ export class UserSettingsBase extends BaseService {
       case 'testing':
         return `https://staging-user-settings-service.services.${this.baseDomain}`;
         case 'local':
-        return `http://localhost:4000/`;
+        return `http://localhost:4000`;
       case 'test':
         return `https://localhost:3010/services/usersettingsservice`;
       default:


### PR DESCRIPTION
This pull request includes a minor update to the `src/services/user_settings_base.ts` file. The change removes the trailing slash from the local environment URL in the `UserSettingsBase` class to standardize the URL format.

* [`src/services/user_settings_base.ts`](diffhunk://#diff-fb24c109d550b992354b14c124300f842deb9f8dfd3d6e3e4745f5823f1efea1L12-R12): Updated the `local` environment URL in the `getBaseUrl` method to remove the trailing slash (`http://localhost:4000/` → `http://localhost:4000`).