### PR TITLE
[TASK] [AB#94590] Add missing client settings type

### DIFF
--- a/src/services/user_settings_clientsettings.ts
+++ b/src/services/user_settings_clientsettings.ts
@@ -23,6 +23,7 @@ export interface ClientSettings {
   foldersView?: LayoutView;
   foldersSorting?: SortOptions;
   onboardingPromptTime?: string;
+  showOnboardingPrompt?: boolean;
 }
 
 export type DisplayModeOption = 'light' | 'dark' | 'system';


### PR DESCRIPTION
This pull request introduces a minor update to the `ClientSettings` interface in `src/services/user_settings_clientsettings.ts`. The change adds a new optional boolean property, `showOnboardingPrompt`, which can be used to control the visibility of onboarding prompts.