### PR TITLE
[TASK] [AB#149631] Added displayName to Question interface

### DIFF
--- a/src/services/quiz_service.ts
+++ b/src/services/quiz_service.ts
@@ -19,6 +19,7 @@ export interface Question {
   questionId: number;
   name: string;
   introText: string;
+  displayName: string;
   caseSensitive?: boolean;
   shuffle: boolean;
   answerChecked: boolean;


### PR DESCRIPTION
This pull request introduces a minor update to the `Question` interface in `src/services/quiz_service.ts`, adding a new property to support additional question metadata.

- Added a new `displayName` property to the `Question` interface, which can be used to provide a user-friendly name for questions.