### PR TITLE
[TASK] [AB#150432] Separated startQuiz method into multiple methods

### DIFF
--- a/src/services/quiz_service.ts
+++ b/src/services/quiz_service.ts
@@ -613,15 +613,15 @@ export class QuizService extends BaseService {
   // ─────────────────────────────────────────────────────────────
 
   async addSharedQuiz({
-    quiz,
+    quizSessionId,
     extraHeaders,
     timeout = REQUEST_TIMEOUT
   }: {
-    quiz: number;
+    quizSessionId: number;
     extraHeaders?: Record<string, string>;
     timeout?: number;
   }): Promise<QuizStartResponse> {
-    const url = `${this.getUrlPrefix()}/shared/student/${quiz}`;
+    const url = `${this.getUrlPrefix()}/shared/student/${quizSessionId}`;
     const headers = this.makeHeaders(extraHeaders);
 
     const res = await this.postAsync({ url, headers, body: '{}', timeout });
@@ -629,19 +629,18 @@ export class QuizService extends BaseService {
   }
 
   async setQuizStartTime({
-    quiz,
+    quizUnitId,
     extraHeaders,
     timeout = REQUEST_TIMEOUT
   }: {
-    quiz: number;
+    quizUnitId: number;
     extraHeaders?: Record<string, string>;
     timeout?: number;
-  }): Promise<string> {
-    const url = `${this.getUrlPrefix()}/shared/student/${quiz}/start`;
+  }): Promise<void> {
+    const url = `${this.getUrlPrefix()}/shared/student/${quizUnitId}/start`;
     const headers = this.makeHeaders(extraHeaders);
 
-    const res = await this.putAsync({ url, headers, body: '{}', timeout });
-    return await res.json();
+    await this.putAsync({ url, headers, body: '{}', timeout });
   }
 
   async createSharedQuiz({

--- a/src/services/quiz_service.ts
+++ b/src/services/quiz_service.ts
@@ -462,20 +462,15 @@ export class QuizService extends BaseService {
   async startQuiz({
     isbn,
     quiz,
-    shared,
     extraHeaders,
     timeout = REQUEST_TIMEOUT
   }: {
     isbn: string;
     quiz: number;
-    shared?: boolean;
     extraHeaders?: Record<string, string>;
     timeout?: number;
   }): Promise<QuizStartResponse> {
-    const url = shared
-      ? `${this.getUrlPrefix()}/shared/student/${quiz}`
-      : `${this.getUrlPrefix()}/isbn/${isbn}/quiz/${quiz}`;
-
+    const url = `${this.getUrlPrefix()}/isbn/${isbn}/quiz/${quiz}`;
     const headers = this.makeHeaders(extraHeaders);
 
     const res = await this.postAsync({ url, headers, body: '{}', timeout });
@@ -616,6 +611,38 @@ export class QuizService extends BaseService {
   // ─────────────────────────────────────────────────────────────
   // Shared quizzes
   // ─────────────────────────────────────────────────────────────
+
+  async addSharedQuiz({
+    quiz,
+    extraHeaders,
+    timeout = REQUEST_TIMEOUT
+  }: {
+    quiz: number;
+    extraHeaders?: Record<string, string>;
+    timeout?: number;
+  }): Promise<QuizStartResponse> {
+    const url = `${this.getUrlPrefix()}/shared/student/${quiz}`;
+    const headers = this.makeHeaders(extraHeaders);
+
+    const res = await this.postAsync({ url, headers, body: '{}', timeout });
+    return await res.json();
+  }
+
+  async setQuizStartTime({
+    quiz,
+    extraHeaders,
+    timeout = REQUEST_TIMEOUT
+  }: {
+    quiz: number;
+    extraHeaders?: Record<string, string>;
+    timeout?: number;
+  }): Promise<string> {
+    const url = `${this.getUrlPrefix()}/shared/student/${quiz}/start`;
+    const headers = this.makeHeaders(extraHeaders);
+
+    const res = await this.putAsync({ url, headers, body: '{}', timeout });
+    return await res.json();
+  }
 
   async createSharedQuiz({
     quizData,


### PR DESCRIPTION
This pull request refactors how shared quizzes are handled in the `QuizService` and introduces new methods for shared quiz operations. The changes separate shared quiz logic from the `startQuiz` method and add dedicated methods for starting and setting the start time of shared quizzes.

Shared quiz handling improvements:

* Removed the `shared` parameter from the `startQuiz` method and simplified its URL logic to only handle regular quizzes. (`src/services/quiz_service.ts`, [src/services/quiz_service.tsL465-R473](diffhunk://#diff-391abfe245c8e418b6ca9943c9351d5581b1b3c10d87ef46ec04ea3d514b2100L465-R473))
* Added a new `addSharedQuiz` method to handle starting shared quizzes via the appropriate endpoint. (`src/services/quiz_service.ts`, [src/services/quiz_service.tsR615-R646](diffhunk://#diff-391abfe245c8e418b6ca9943c9351d5581b1b3c10d87ef46ec04ea3d514b2100R615-R646))
* Introduced a `setQuizStartTime` method for setting the start time of a shared quiz. (`src/services/quiz_service.ts`, [src/services/quiz_service.tsR615-R646](diffhunk://#diff-391abfe245c8e418b6ca9943c9351d5581b1b3c10d87ef46ec04ea3d514b2100R615-R646))