### PR TITLE
[TASK] [AB#150972] Added type

### DIFF
--- a/src/services/user_settings_clientsettings.ts
+++ b/src/services/user_settings_clientsettings.ts
@@ -12,6 +12,7 @@ export interface ClientSettings {
   showBookmarks?: boolean;
   showNoteHighlights?: boolean;
   featureGalleryVersion?: number;
+  highlightsSorting?: HighlightsSorting;
   readAloudStore?: ReadAloudStore;
   leftDrawerWidth?: number;
   recentSearches?: string[];
@@ -77,6 +78,8 @@ export interface FrontPageSection {
 }
 
 export type SortOptions = 'recent' | 'alphabetical';
+
+export type HighlightsSorting = 'newest' | 'chapters';
 
 export class UserSettingsClientSettings extends UserSettingsBase {
   async getSettings({


### PR DESCRIPTION
This pull request introduces a new highlights sorting option to the user settings interface, allowing highlights to be sorted either by "newest" or by "chapters". The main changes are focused on extending the type definitions to support this new feature.

**Enhancements to highlights sorting:**

* Added a new `HighlightsSorting` type (`'newest' | 'chapters'`) to define possible sorting options for highlights.
* Extended the `ClientSettings` interface to include an optional `highlightsSorting` property of type `HighlightsSorting`.