### PR TITLE
[TASK] [AB#159215] Use npm for publish (for now).

### DIFF
--- a/.github/workflows/npm-publish-github-packages.yml
+++ b/.github/workflows/npm-publish-github-packages.yml
@@ -23,6 +23,6 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: npm version "${{ github.event.release.tag_name }}" --no-git-tag-version
       - run: pnpm run build
-      - run: pnpm publish --access public --no-git-checks
+      - run: npm publish --access public --no-git-checks
         env:
           NODE_AUTH_TOKEN: ${{ secrets.PUBLIC_NPM_AUTH_TOKEN }}


### PR DESCRIPTION
In pnpm 11 the publish functionality was integrated rather than just calling npm. Unfortunately this obviously requires a fair number of changes to be compatible, retain old behavior for now.